### PR TITLE
Make modal parent of client request components

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,15 +1,19 @@
 import { Route, Switch } from "react-router-dom";
+import { useState } from "react";
 import pragmaticplumberlogo from "/src/assets/pragmaticplumberlogo.png";
 import Nav from "./components/Nav";
 import Login from "./pages/Login";
 import Signup from "./pages/Signup";
 import Dashboard from "./pages/Dashboard";
 import ServiceRequest from "./pages/ServiceRequest";
+import Modal from "./components/Modal";
 import Footer from "./components/Footer.jsx";
-
 import "./css/App.css";
 
 function App() {
+  const [open, setOpen] = useState(false)
+  const handleCloseModal = () => setOpen(!open)
+
   return (
     <>
       <div>
@@ -34,7 +38,7 @@ function App() {
             render={(props) => <Dashboard {...props} />}
           />
         </Switch>
-        <ServiceRequest />
+        <Modal isOpen={!open} onClose={handleCloseModal} children={<ServiceRequest />} />
         <Footer />
       </div>
     </>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -38,7 +38,7 @@ function App() {
             render={(props) => <Dashboard {...props} />}
           />
         </Switch>
-        <Modal isOpen={!open} onClose={handleCloseModal} children={<ServiceRequest />} />
+        <Modal isOpen={open} onClose={handleCloseModal} children={<ServiceRequest />} /> {/*to test modal, change isOpen={!open}*/}
         <Footer />
       </div>
     </>

--- a/src/components/AppointmentScheduler.jsx
+++ b/src/components/AppointmentScheduler.jsx
@@ -5,6 +5,8 @@ import { Context } from "../context/Context";
 function AppointmentScheduler() {
   const { selectedService, appointment, setAppointment } = useContext(Context);
 
+  if (!selectedService) return <h3>Loading...</h3>
+
   const currentDate = new Date();
   const todayString = currentDate.toISOString().split("T")[0];
   const nextWeekString = add(currentDate, { days: 6 })
@@ -52,9 +54,14 @@ function AppointmentScheduler() {
       tech_id: 1, // NOTE - here we are hard-coding the first technician's tech_id into the future POST body
     });
   };
+
+  const timeEstimate = () => {
+    let minutes = parseInt(selectedService.estimated_time)
+    return (minutes >= 60) ? `${minutes / 60} hour(s)` : `${minutes} minutes`
+  }
   const renderTimeButtons = times().map((t, i) => {
     return (
-      <button key={i} value={t} onClick={handleSlotSelection}>
+      <button type="button" key={i} value={t} onClick={handleSlotSelection}>
         {t}
       </button>
     );
@@ -62,7 +69,8 @@ function AppointmentScheduler() {
 
   return (
     <div>
-      <p>Estimated completion time: {selectedService.estimated_time} minutes</p>
+      <h1>Select a Date and a Start Time</h1>
+      <p>Estimated completion time: {timeEstimate()}</p>
       <input
         type="date"
         min={todayString}
@@ -71,6 +79,7 @@ function AppointmentScheduler() {
       />
       <br />
       {renderTimeButtons}
+      <br />
     </div>
   );
 }

--- a/src/components/ClientInfoForm.jsx
+++ b/src/components/ClientInfoForm.jsx
@@ -14,83 +14,53 @@ const ClientInfoForm = () => {
     });
   };
 
-  //Handle submission
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-
-    console.log("Form Data Submitted:", appointment);
-    //Send data to calendar API
-    try {
-      const response = await fetch(
-        "https://booking-app.us-east-1.elasticbeanstalk.com/service-provider/api/v1/appointments",
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(appointment),
-        },
-      );
-
-      if (!response.ok) {
-        throw new Error("Failed to submit data");
-      }
-
-      const result = await response.json();
-      console.log("Success:", result);
-      alert("Form submitted successfully");
-    } catch (error) {
-      console.error("Error:", error);
-      alert("Failed to submit form");
-    }
-  };
-
   return (
     <div>
-      <section id="client_request"></section> <br />
+      <h1>Client Information</h1>
       <section id="client_info">
-        <form onSubmit={handleSubmit}>
-          <label htmlFor="name">Name: </label>
-          <input
-            type="text"
-            id="name"
-            value={appointment.name}
-            onChange={handleInputChange}
-          />{" "}
-          <br />
-          <label htmlFor="email">Email: </label>
-          <input
-            type="email"
-            id="email"
-            value={appointment.email}
-            onChange={handleInputChange}
-          />
-          <br />
-          <label htmlFor="address">Address: </label>
-          <input
-            type="text"
-            id="address"
-            value={appointment.address}
-            onChange={handleInputChange}
-          />
-          <br />
-          <label htmlFor="phone">Phone Number: </label>
-          <input
-            type="tel"
-            id="phone"
-            value={appointment.phone}
-            onChange={handleInputChange}
-          />
-          <br />
-          <label htmlFor="comment">Comments: </label>
-          <textarea
-            id="comment"
-            value={appointment.comment}
-            onChange={handleInputChange}
-          />
-          <br />
-          <button type="submit">Submit</button>
-        </form>
+        <label htmlFor="name">Full Name: </label>
+        <input
+          required
+          type="text"
+          id="name"
+          value={appointment.name}
+          onChange={handleInputChange}
+        />{" "}
+        <br />
+        <label htmlFor="email">Email: </label>
+        <input
+          required
+          type="email"
+          id="email"
+          value={appointment.email}
+          onChange={handleInputChange}
+        />
+        <br />
+        <label htmlFor="address">Address: </label>
+        <input
+          required
+          type="text"
+          id="address"
+          value={appointment.address}
+          onChange={handleInputChange}
+        />
+        <br />
+        <label htmlFor="phone">Phone Number: </label>
+        <input
+          required
+          type="tel"
+          id="phone"
+          value={appointment.phone}
+          onChange={handleInputChange}
+        />
+        <br />
+        <label htmlFor="comment">Comments: </label>
+        <textarea
+          required
+          id="comment"
+          value={appointment.comment}
+          onChange={handleInputChange}
+        />
       </section>
     </div>
   );

--- a/src/components/Message.jsx
+++ b/src/components/Message.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const Message = ({ text, style }) => {
+  return (
+    <div className={style}>{text}</div>
+  )
+}
+
+export default Message

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const Modal = ({ isOpen, onClose, children }) => {
+  if (!isOpen) return null;
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+        <button className="modal-close" onClick={onClose}>&times;</button>
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -5,7 +5,7 @@ const Modal = ({ isOpen, onClose, children }) => {
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal-content" onClick={(e) => e.stopPropagation()}>
-        <button className="modal-close" onClick={onClose}>&times;</button>
+        <button className="modal-close" onClick={onClose}>X</button>
         {children}
       </div>
     </div>

--- a/src/components/Services.jsx
+++ b/src/components/Services.jsx
@@ -35,6 +35,7 @@ export default function Services() {
 
   const renderServiceButtons = services.map((s) => (
     <button
+      type="button"
       key={s.service_id}
       onClick={handleSelectService}
       className="services"
@@ -46,6 +47,7 @@ export default function Services() {
 
   return (
     <>
+      <h1>Select a Service</h1>
       <div className="services-nav">{renderServiceButtons}</div>
     </>
   );

--- a/src/css/App.css
+++ b/src/css/App.css
@@ -140,3 +140,43 @@ footer {
   align-items: center;
   margin: 2rem;
 }
+
+.modal-overlay {
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 999;
+}
+
+.modal-content {
+  position: fixed;
+  background-color: #f0f0f0;
+  border: 3px solid #000000;
+  border-radius: 5px;
+  box-shadow: 2px 3px 3px 1px rgba(50, 48, 50, 0.5);
+  width: 50vw;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 2%;
+  z-index: 1000;
+}
+
+.modal-close {
+  position: absolute;
+  top: .5rem;
+  right: .5rem
+}
+
+
+/* Styling for Message component */
+.success {
+  background-color: green;
+}
+
+.failure {
+  background-color: red;
+}

--- a/src/hooks/useMultistepForm.jsx
+++ b/src/hooks/useMultistepForm.jsx
@@ -1,0 +1,34 @@
+import { useState } from "react"
+
+export function useMultistepForm(steps) {
+  const [currentStepIndex, setCurrentStepIndex] = useState(0)
+
+  function next() {
+    setCurrentStepIndex(i => {
+      if (i >= steps.length - 1) return i
+      return i + 1
+    })
+  }
+
+  function back() {
+    setCurrentStepIndex(i => {
+      if (i <= 0) return i
+      return i - 1
+    })
+  }
+
+  function goTo(index) {
+    setCurrentStepIndex(index)
+  }
+
+  return {
+    currentStepIndex,
+    step: steps[currentStepIndex],
+    steps,
+    isFirstStep: currentStepIndex === 0,
+    isLastStep: currentStepIndex === steps.length - 1,
+    goTo,
+    next,
+    back,
+  }
+}

--- a/src/pages/ServiceRequest.jsx
+++ b/src/pages/ServiceRequest.jsx
@@ -1,20 +1,79 @@
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
+import { useMultistepForm } from "../hooks/useMultistepForm";
 import Services from "../components/Services";
 import AppointmentScheduler from "../components/AppointmentScheduler";
 import ClientInfoForm from "../components/ClientInfoForm";
+import Message from "../components/Message";
 import { Context } from "../context/Context";
 
 const ServiceRequest = () => {
   const { selectedService, appointment } = useContext(Context);
-  const { service_id, date, time_slot } = appointment;
-  //TODO: cleaner conditional rendering
+  const { date, time_slot } = appointment;
+  const [message, setMessage] = useState(null)
+  const { steps, currentStepIndex, step, isFirstStep, isLastStep, back, next } = useMultistepForm([
+    <Services />,
+    <AppointmentScheduler />,
+    <ClientInfoForm />
+  ])
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!selectedService) return alert("Please select a service")
+    if (currentStepIndex === 1 && (!date || !time_slot)) return alert("Please select a date and time for your appointment")
+    if (!isLastStep) return next()
+
+    console.log("Form Data Submitted:", appointment);
+    try {
+      const response = await fetch(
+        "https://booking-app.us-east-1.elasticbeanstalk.com/service-provider/api/v1/appointments",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(appointment),
+        },
+      );
+
+      const result = await response.json(); // response could be used to interpolate the date and time info into the success message
+      setMessage({
+        style: "success",
+        text: "You have successfully booked your appointment! You will receive a confirmation email shortly."
+      })
+    } catch (error) {
+      console.error("Error:", error);
+      setMessage({
+        style: "failure",
+        text: "We were unable to submit your appointment request. Please try again."
+      })
+    }
+  };
+
+  if (message) return <Message style={message.style} text={message.text} />
 
   return (
-    <>
-      {!service_id && <Services />}
-      {selectedService && (!date || !time_slot) && <AppointmentScheduler />}
-      {time_slot && date && <ClientInfoForm />}
-    </>
+    <form onSubmit={handleSubmit}>
+      <div style={{ position: "absolute", bottom: ".5rem", right: ".5rem" }}>
+        {currentStepIndex + 1} / {steps.length}
+      </div>
+      {step}
+      <div
+        style={{
+          marginTop: "1rem",
+          display: "flex",
+          gap: ".5rem",
+          justifyContent: "flex-end",
+        }}
+      >
+        {!isFirstStep && (
+          <button type="button" onClick={back}>
+            Back
+          </button>
+        )}
+        <button type="submit">{isLastStep ? "Finish" : "Next"}</button>
+      </div>
+    </form>
+
   );
 };
 


### PR DESCRIPTION
![Mar-13-2025 15-27-23](https://github.com/user-attachments/assets/ddda9d96-dfb1-43f1-8abd-7d3e67f0b671)

 - Moved all ServiceRequest components into the Modal
 - Created a hook to navigate the different components with 'Back' and 'Next' buttons
 - Added a Message component to display at form submission, can be reused for other errors/alerts
 - Included alerts to urge the client to select/fill out blank fields before moving on.
 
NOTES
 - The Modal needs to be attached to the 'Book Online' button in the header. 
 - To test out the modal in this branch, it can be opened by changing the isOpen prop to 'true' in App.jsx
 - Buttons rendered inside of the form element of ServiceRequest.jsx (i.e., the ones in the child components) will trigger the onSubmit by default, so their type attributes have been explicitly set to "button". We may encounter this issue with the reusable Button component at first.
 - Finally, the selected service and appointment time will be made more apparent with styling in a later branch. Was just going for functionality and flow here.
