### PR TITLE
Admin can Accept or Decline Jobs, See Inventory Stock indicator, and Save Notes + AG Grid tables

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.0.14",
+    "ag-grid-react": "^33.1.1",
     "date-fns": "^4.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/components/AppointmentDetails.jsx
+++ b/src/components/AppointmentDetails.jsx
@@ -23,6 +23,18 @@ function AppointmentDetails({ appointment, setAppointment }) {
       })
   }
 
+  const handleSaveNotes = async () => {
+    fetch(`https://booking-app.us-east-1.elasticbeanstalk.com/service-provider/api/v1/appointments/admin/${appointment_id}`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...appointment.appointment,
+          admin_note: note
+        })
+      })
+  }
+
   const itemTable = appointment.items.map(i => {
     return (
       <tr key={i.item_id} className="text-center text-sm" style={{ padding: "10px" }}>
@@ -98,7 +110,7 @@ function AppointmentDetails({ appointment, setAppointment }) {
         <button className="button" onClick={() => setNote("")}>Discard</button>
         <button disabled={disabled} className="button" onClick={() => handleUpdateStatus("Accepted")}>Accept</button>
         <button disabled={disabled} className="button" onClick={() => handleUpdateStatus("Declined")}>Decline</button>
-        <button className="button">Save</button>
+        <button className="button" onClick={handleSaveNotes}>Save</button>
       </div>
     </>
   );

--- a/src/components/AppointmentDetails.jsx
+++ b/src/components/AppointmentDetails.jsx
@@ -76,13 +76,13 @@ function AppointmentDetails({ appointment, setAppointment }) {
           </tbody>
         </table>
         <h1>Notes</h1>
-        <textarea className="w-full h-32">
+        <textarea className="w-full h-32 border">
 
         </textarea>
         <br />
         <button className="button">DISCARD</button>
         <button disabled={disabled} className="button" onClick={() => setDisabled(true)}>Accept</button>
-        <button className="button" onClick={() => setAppointment(null)}>Decline</button>
+        <button disabled={disabled} className="button" onClick={() => setAppointment(null)}>Decline</button>
         <button className="button">Save</button>
       </div>
     </>

--- a/src/components/AppointmentDetails.jsx
+++ b/src/components/AppointmentDetails.jsx
@@ -6,7 +6,7 @@ function AppointmentDetails({ appointment, setAppointment }) {
   const { appointment_id, client_name, client_email, client_phone, start_time, end_time, issue_description, estimated_time, status, service_id, location, admin_note, assigned_technician_list, quoted_price, missing_item_list } = appointment.appointment;
 
   const [note, setNote] = useState(admin_note ?? "") // admin_note comes in as null by default, and the value prop of a textarea cannot be null
-  const [disabled, setDisabled] = useState(status === ("ACCEPTED" || "REJECTED") ? true : false)
+  const [disabled, setDisabled] = useState(status === "ACCEPTED" || status === "REJECTED" ? true : false)
   const handleUpdateStatus = async (newStatus) => {
     fetch(`https://booking-app.us-east-1.elasticbeanstalk.com/service-provider/api/v1/appointments/admin/${appointment_id}/${newStatus}`,
       {

--- a/src/components/AppointmentDetails.jsx
+++ b/src/components/AppointmentDetails.jsx
@@ -6,7 +6,7 @@ function AppointmentDetails({ appointment, setAppointment }) {
   const { appointment_id, client_name, client_email, client_phone, start_time, end_time, issue_description, estimated_time, status, service_id, location, admin_note, assigned_technician_list, quoted_price, missing_item_list } = appointment.appointment;
 
   const [note, setNote] = useState(admin_note ?? "") // admin_note comes in as null by default, and the value prop of a textarea cannot be null
-
+  const [disabled, setDisabled] = useState(status === ("ACCEPTED" || "REJECTED") ? true : false)
   const handleUpdateStatus = async (newStatus) => {
     fetch(`https://booking-app.us-east-1.elasticbeanstalk.com/service-provider/api/v1/appointments/admin/${appointment_id}/${newStatus}`,
       {

--- a/src/components/AppointmentDetails.jsx
+++ b/src/components/AppointmentDetails.jsx
@@ -95,7 +95,7 @@ function AppointmentDetails({ appointment, setAppointment }) {
         <h1>Notes</h1>
         <textarea className="w-full h-32 border" value={note} onChange={(e) => setNote(e.target.value)}></textarea>
         <br />
-        <button className="button">DISCARD</button>
+        <button className="button" onClick={() => setNote("")}>Discard</button>
         <button disabled={disabled} className="button" onClick={() => handleUpdateStatus("Accepted")}>Accept</button>
         <button disabled={disabled} className="button" onClick={() => handleUpdateStatus("Declined")}>Decline</button>
         <button className="button">Save</button>

--- a/src/components/AppointmentDetails.jsx
+++ b/src/components/AppointmentDetails.jsx
@@ -1,52 +1,42 @@
 import { useState } from 'react';
+import DataGrid from "./DataGrid";
 
 function AppointmentDetails({ appointment, setAppointment }) {
   if (!appointment) return <h1>Loading...</h1>
   const { appointment_id, client_name, client_email, client_phone, start_time, end_time, issue_description, estimated_time, status, service_id, location, admin_note, assigned_technician_list, quoted_price, missing_item_list } = appointment.appointment;
 
-  const [disabled, setDisabled] = useState(false)
   const [note, setNote] = useState(admin_note ?? "") // admin_note comes in as null by default, and the value prop of a textarea cannot be null
 
   const handleUpdateStatus = async (newStatus) => {
-    fetch(`https://booking-app.us-east-1.elasticbeanstalk.com/service-provider/api/v1/appointments/admin/${appointment_id}`,
+    fetch(`https://booking-app.us-east-1.elasticbeanstalk.com/service-provider/api/v1/appointments/admin/${appointment_id}/${newStatus}`,
       {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          ...appointment.appointment,
-          status: newStatus
-        })
       })
-      .then(() => { // this part can be changed to work from the response object; ideally we will show a confirmation to the admin
-        if (newStatus === "Accepted") setDisabled(true)
-        if (newStatus === "Declined") setAppointment(null)
-      })
+      .then(res => res.json())
+      .then(data => alert(`You have ${data.status} this appointment.`))
   }
 
+  const disabled = status === "ACCEPTED" || "REJECTED" ? true : false
   const handleSaveNotes = async () => {
-    fetch(`https://booking-app.us-east-1.elasticbeanstalk.com/service-provider/api/v1/appointments/admin/${appointment_id}`,
+    fetch(`https://booking-app.us-east-1.elasticbeanstalk.com/service-provider/api/v1/appointments/admin/`,
       {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          ...appointment.appointment,
+          appointment_id: appointment_id,
           admin_note: note
         })
       })
   }
 
-  const itemTable = appointment.items.map(i => {
-    return (
-      <tr key={i.item_id} className="text-center text-sm" style={{ padding: "10px" }}>
-        <td className="px-2 py-2">{i.item.item_name}</td>
-        <td className="px-2 py-2">{i.qty_needed}</td>
-        <td className="px-2 py-2">{i.outOfStock === false ? "Yes" : "No"}</td>
-        <td className="px-2 py-2">{i.item.unit_price}</td>
-        {/* Total Cost */}
-      </tr>
-    );
-  }
-  );
+  const apptRowData = [{ "Client Name": client_name, "Phone": client_phone, "Email": client_email, "Address": location, "Comments": issue_description, "Date Selected": start_time?.split("T")[0], "Time Selected": end_time, "Estimated Time": estimated_time, "Status": status }]
+  const apptColDefs = [{ field: "Client Name" }, { field: "Phone" }, { field: "Email" }, { field: "Address" }, { field: "Comments" }, { field: "Date Selected" }, { field: "Time Selected" }, { field: "Estimated Time" }, { field: "Status" }]
+
+  const itemRowData = appointment.items.map(i => ({ "Name": i.item.item_name, "Qty Needed": i.qty_needed, "In Stock": i.outOfStock ? "No" : "Yes", "Unit Price": i.item.unit_price }))
+  const itemColDefs = [{ field: "Name" }, { field: "Qty Needed" }, { field: "In Stock" }, { field: "Unit Price" }]
+
+
   return (
     <>
       <div>
@@ -59,60 +49,19 @@ function AppointmentDetails({ appointment, setAppointment }) {
         active:scale-90"
           onClick={() => setAppointment(null)}>X</button>
         <h1>Client Information</h1>
-        <table className="min-w-full table-auto border-collapse">
-          <thead>
-            <tr className="text-center text-sm">
-              <th className="px-2 py-2">Client Name</th>
-              <th className="px-2 py-2">Phone</th>
-              <th className="px-2 py-2">Email</th>
-              <th className="px-2 py-2">Address</th>
-              <th className="px-2 py-2">Comments</th>
-              <th className="px-2 py-2">Date Selected</th>
-              <th className="px-2 py-2">Time Selected</th>
-              <th className="px-2 py-2">Estimated Time</th>
-              <th className="px-2 py-2">Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td className="px-2 py-2">{client_name}</td>
-              <td className="px-2 py-2">{client_phone}</td>
-              <td className="px-2 py-2">{client_email}</td>
-              <td className="px-2 py-2">{location}</td>
-              <td className="px-2 py-2">{issue_description}</td>
-              {/* <td className="px-2 py-2">{}</td> */}
-              <td className="px-2 py-2">{start_time?.split("T")[0]}</td>
-              <td className="px-2 py-2">{end_time}</td>
-              <td className="px-2 py-2">{estimated_time}</td>
-              <td className="px-2 py-2">{status}</td>
-            </tr>
-          </tbody>
-        </table>
+        <DataGrid rowData={apptRowData} colDefs={apptColDefs} height={100} />
       </div>
       <div>
         <h1>Inventory Check</h1>
-        <table className="min-w-full table-auto border-collapse">
-          <thead>
-            <tr className="text-center text-sm">
-              <th className="px-2 py-2">Name</th>
-              <th className="px-2 py-2">Qty Needed</th>
-              <th className="px-2 py-2">In Stock</th>
-              <th className="px-2 py-2">Unit Price</th>
-              {/* <th className="px-2 py-2">Total Cost</th> */}
-            </tr>
-          </thead>
-          <tbody>
-            {itemTable}
-          </tbody>
-        </table>
+        <DataGrid rowData={itemRowData} colDefs={itemColDefs} height={300} />
         <h1>Notes</h1>
         <textarea className="w-full h-32 border" value={note} onChange={(e) => setNote(e.target.value)}></textarea>
         <br />
         <button className="button" onClick={handleSaveNotes}>Save Notes</button>
         <button className="button" onClick={() => setNote("")}>Discard</button>
         <br /><br />
-        <button disabled={disabled} className="button" onClick={() => handleUpdateStatus("Accepted")}>Accept</button>
-        <button disabled={disabled} className="button" onClick={() => handleUpdateStatus("Declined")}>Decline</button>
+        <button disabled={disabled} className="button" onClick={() => handleUpdateStatus("ACCEPTED")}>Accept</button>
+        <button disabled={disabled} className="button" onClick={() => handleUpdateStatus("REJECTED")}>Decline</button>
       </div>
     </>
   );

--- a/src/components/AppointmentDetails.jsx
+++ b/src/components/AppointmentDetails.jsx
@@ -70,6 +70,7 @@ function AppointmentDetails({ appointment, setAppointment }) {
               <th className="px-2 py-2">Date Selected</th>
               <th className="px-2 py-2">Time Selected</th>
               <th className="px-2 py-2">Estimated Time</th>
+              <th className="px-2 py-2">Status</th>
             </tr>
           </thead>
           <tbody>
@@ -108,9 +109,10 @@ function AppointmentDetails({ appointment, setAppointment }) {
         <textarea className="w-full h-32 border" value={note} onChange={(e) => setNote(e.target.value)}></textarea>
         <br />
         <button className="button" onClick={() => setNote("")}>Discard</button>
+        <button className="button" onClick={handleSaveNotes}>Save</button>
+        <br /><br />
         <button disabled={disabled} className="button" onClick={() => handleUpdateStatus("Accepted")}>Accept</button>
         <button disabled={disabled} className="button" onClick={() => handleUpdateStatus("Declined")}>Decline</button>
-        <button className="button" onClick={handleSaveNotes}>Save</button>
       </div>
     </>
   );

--- a/src/components/AppointmentDetails.jsx
+++ b/src/components/AppointmentDetails.jsx
@@ -5,6 +5,21 @@ function AppointmentDetails({ appointment, setAppointment }) {
   const { appointment_id, client_name, client_email, client_phone, start_time, end_time, issue_description, estimated_time, status, service_id, location, admin_note, assigned_technician_list, quoted_price, missing_item_list } = appointment.appointment;
 
   const [disabled, setDisabled] = useState(false)
+  const handleUpdateStatus = async (newStatus) => {
+    fetch(`https://booking-app.us-east-1.elasticbeanstalk.com/service-provider/api/v1/appointments/admin/${appointment_id}`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...appointment.appointment,
+          status: newStatus
+        })
+      })
+      .then(() => { // this part can be changed to work from the response object; ideally we will show a confirmation to the admin
+        if (newStatus === "Accepted") setDisabled(true)
+        if (newStatus === "Declined") setAppointment(null)
+      })
+  }
 
   const itemTable = appointment.items.map(i => {
     return (
@@ -81,8 +96,8 @@ function AppointmentDetails({ appointment, setAppointment }) {
         </textarea>
         <br />
         <button className="button">DISCARD</button>
-        <button disabled={disabled} className="button" onClick={() => setDisabled(true)}>Accept</button>
-        <button disabled={disabled} className="button" onClick={() => setAppointment(null)}>Decline</button>
+        <button disabled={disabled} className="button" onClick={() => handleUpdateStatus("Accepted")}>Accept</button>
+        <button disabled={disabled} className="button" onClick={() => handleUpdateStatus("Declined")}>Decline</button>
         <button className="button">Save</button>
       </div>
     </>

--- a/src/components/AppointmentDetails.jsx
+++ b/src/components/AppointmentDetails.jsx
@@ -14,10 +14,17 @@ function AppointmentDetails({ appointment, setAppointment }) {
         headers: { 'Content-Type': 'application/json' },
       })
       .then(res => res.json())
-      .then(data => alert(`You have ${data.status} this appointment.`))
+      .then(data => {
+        setAppointment({
+          ...appointment,
+          status: data.status
+        })
+        setDisabled(true)
+        alert(`You have ${data.status} this appointment.`)
+      })
   }
 
-  const disabled = status === "ACCEPTED" || "REJECTED" ? true : false
+
   const handleSaveNotes = async () => {
     fetch(`https://booking-app.us-east-1.elasticbeanstalk.com/service-provider/api/v1/appointments/admin/`,
       {

--- a/src/components/AppointmentDetails.jsx
+++ b/src/components/AppointmentDetails.jsx
@@ -5,6 +5,8 @@ function AppointmentDetails({ appointment, setAppointment }) {
   const { appointment_id, client_name, client_email, client_phone, start_time, end_time, issue_description, estimated_time, status, service_id, location, admin_note, assigned_technician_list, quoted_price, missing_item_list } = appointment.appointment;
 
   const [disabled, setDisabled] = useState(false)
+  const [note, setNote] = useState(admin_note ?? "") // admin_note comes in as null by default, and the value prop of a textarea cannot be null
+
   const handleUpdateStatus = async (newStatus) => {
     fetch(`https://booking-app.us-east-1.elasticbeanstalk.com/service-provider/api/v1/appointments/admin/${appointment_id}`,
       {
@@ -91,9 +93,7 @@ function AppointmentDetails({ appointment, setAppointment }) {
           </tbody>
         </table>
         <h1>Notes</h1>
-        <textarea className="w-full h-32 border">
-
-        </textarea>
+        <textarea className="w-full h-32 border" value={note} onChange={(e) => setNote(e.target.value)}></textarea>
         <br />
         <button className="button">DISCARD</button>
         <button disabled={disabled} className="button" onClick={() => handleUpdateStatus("Accepted")}>Accept</button>

--- a/src/components/AppointmentDetails.jsx
+++ b/src/components/AppointmentDetails.jsx
@@ -108,8 +108,8 @@ function AppointmentDetails({ appointment, setAppointment }) {
         <h1>Notes</h1>
         <textarea className="w-full h-32 border" value={note} onChange={(e) => setNote(e.target.value)}></textarea>
         <br />
+        <button className="button" onClick={handleSaveNotes}>Save Notes</button>
         <button className="button" onClick={() => setNote("")}>Discard</button>
-        <button className="button" onClick={handleSaveNotes}>Save</button>
         <br /><br />
         <button disabled={disabled} className="button" onClick={() => handleUpdateStatus("Accepted")}>Accept</button>
         <button disabled={disabled} className="button" onClick={() => handleUpdateStatus("Declined")}>Decline</button>

--- a/src/components/AppointmentsList.jsx
+++ b/src/components/AppointmentsList.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import DataGrid from "./DataGrid";
 
 function AppointmentsList({ setAppointment }) {
   const [appointments, setAppointments] = useState([]);
@@ -52,53 +53,26 @@ function AppointmentsList({ setAppointment }) {
     }
   };
 
-
-  const appointmentTable = appointments.map((appointment) => {
+  const customButton = props => {
     return (
-      <tr key={appointment.appointment_id}>
-        <td className="px-2 py-2">{appointment.appointment_id}</td>
-        <td className="px-2 py-2">{appointment.service_id.service_id}</td>
-        <td className="px-2 py-2">{appointment.client_note}</td>
-        <td className="px-2 py-2">{appointment.issue_description}</td>
-        <td className="px-2 py-2">{appointment.location}</td>
-        <td className="px-2 py-2">{appointment.admin_note}</td>
-        <td className="px-2 py-2">{appointment.created_at}</td>
-        <td className="px-2 py-2">{appointment.updated_at}</td>
-        <td className="px-2 py-2">{appointment.estimated_time}</td>
-        <td className="px-2 py-2">{appointment.status}</td>
-        <td className="px-2 py-2">
-          <button
-            onClick={() => handleAppointmentClick(appointment.appointment_id)}
-            className="bg-[#4BCE4B] rounded-[1rem] no-underline px-[5px] py-[5px] w-[100px] h-[25px] mb-2 mr-2
-        shadow-[inset_0_-25px_18px_-14px_rgba(1,185,38,0.35),0_1px_2px_rgba(1,177,30,0.35),0_2px_4px_rgba(3,194,79,0.35),0_4px_8px_rgba(1,192,17,0.35),0_8px_16px_rgba(1,119,42,0.35),0_16px_32px_rgba(2,199,78,0.35)]
-        text-[#4B4B4B] font-sans border-[1px] border-[#4BCE4B]
-        active:scale-90">
-            View Details
-          </button>
-        </td>
-      </tr>
-    );
-  });
+      <button
+        onClick={() => handleAppointmentClick(props.data["Appointment ID"])}
+        className="button">
+        View Details
+      </button>)
+  }
+  const rowData = appointments.map(a => ({ "Appointment ID": a.appointment_id, "Service ID": a.service_id.service_id, "Description": a.issue_description, "Location": a.location, "Admin Note": a.admin_note, "Estimated Time": a.estimated_time, "Status": a.status }))
+  const colDefs = [{ field: "Appointment ID" }, { field: "Service ID" }, { field: "Description" }, { field: "Location" }, { field: "Admin Note" }, { field: "Estimated Time" }, { field: "Status" }, {
+    field: "actions",
+    headerName: "Actions",
+    cellRenderer: customButton
+
+  }]
+
   return (
     <div>
       <h1>Appointments</h1>
-      <table className="min-w-full table-auto border-collapse">
-        <thead>
-          <tr className="text-center text-sm">
-            <th className="px-2 py-2">Appointment ID</th>
-            <th className="px-2 py-2">Service ID</th>
-            <th className="px-2 py-2">Client Note</th>
-            <th className="px-2 py-2">Description</th>
-            <th className="px-2 py-2">Location</th>
-            <th className="px-2 py-2">Admin Note</th>
-            <th className="px-2 py-2">Created At</th>
-            <th className="px-2 py-2">Updated At</th>
-            <th className="px-2 py-2">Estimated Time</th>
-            <th className="px-2 py-2">Status</th>
-          </tr>
-        </thead>
-        <tbody>{appointmentTable}</tbody>
-      </table>
+      <DataGrid colDefs={colDefs} rowData={rowData} height={500} />
     </div>
   );
 }

--- a/src/components/DataGrid.jsx
+++ b/src/components/DataGrid.jsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { AgGridReact } from 'ag-grid-react';
+import { themeQuartz } from "ag-grid-community";
+
+const DataGrid = ({ rowData, colDefs, height }) => {
+
+  const theme = themeQuartz.withParams({
+    backgroundColor: 'white',
+    foregroundColor: 'black',
+    headerTextColor: '#f0f0f0',
+    headerBackgroundColor: '#00BB03',
+    oddRowBackgroundColor: 'rgb(0, 0, 0, 0.03)',
+    headerColumnResizeHandleColor: 'black',
+  });
+
+  return (
+    <div style={{ height: height }}>
+      <AgGridReact
+        rowData={rowData}
+        columnDefs={colDefs}
+        theme={theme}
+      />
+    </div>
+  )
+}
+
+export default DataGrid

--- a/src/css/App.css
+++ b/src/css/App.css
@@ -28,7 +28,6 @@
   background-image: -webkit-gradient(linear, left bottom, left top, color-stop(0.16, rgb(207, 207, 207)), color-stop(0.79, rgb(252, 252, 252)));
   background-image: -moz-linear-gradient(center bottom, rgb(207, 207, 207) 16%, rgb(252, 252, 252) 79%);
   background-image: linear-gradient(to top, rgb(207, 207, 207) 16%, rgb(252, 252, 252) 79%);
-  padding: 3px;
   margin-inline: 5px;
   border: 1px solid #000;
   color: black;

--- a/src/css/App.css
+++ b/src/css/App.css
@@ -29,6 +29,7 @@
   background-image: -moz-linear-gradient(center bottom, rgb(207, 207, 207) 16%, rgb(252, 252, 252) 79%);
   background-image: linear-gradient(to top, rgb(207, 207, 207) 16%, rgb(252, 252, 252) 79%);
   padding: 3px;
+  margin-inline: 5px;
   border: 1px solid #000;
   color: black;
   text-decoration: none;

--- a/src/css/App.css
+++ b/src/css/App.css
@@ -213,3 +213,8 @@ footer {
 .failure {
   background-color: red;
 }
+
+:disabled {
+  cursor: not-allowed;
+  opacity: 50%;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,11 @@ import { BrowserRouter as Router } from "react-router-dom";
 import { Provider } from "./context/Context.jsx";
 import "./index.css";
 import App from "./App.jsx";
+import { AllCommunityModule, ModuleRegistry } from 'ag-grid-community';
+
+
+ModuleRegistry.registerModules([AllCommunityModule]);
+
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>


### PR DESCRIPTION
![Mar-19-2025 17-24-43](https://github.com/user-attachments/assets/fe607d52-1ce6-4b49-b8f1-b59b7f75cc58)
- Admin can click 'Accept' or 'Decline' and see a confirmation message. Buttons are disabled for appointments with the status of 'ACCEPTED' or 'REJECTED'.
- Appointment notes are preloaded into the appointment details if there are any, and Admin can save notes to the DB. Clicking discard clears the textbox, but does not delete any saved notes.
- Admin can see an 'In Stock' indicator on an appointment that they click
- Added ag-grid-react to have dynamic, sortable tables to display appointment data