### PR TITLE
Fix service bug and error message

### DIFF
--- a/src/css/App.css
+++ b/src/css/App.css
@@ -58,11 +58,11 @@ button.services {
 
 /* Styling for Message component */
 .success {
-  @apply bg-green-300;
+  @apply rounded-xl py-8 px-1 text-xs font-semibold bg-green-300 text-green-800;
 }
 
 .failure {
-  background-color: red;
+  @apply rounded-xl py-8 px-1 text-xs font-semibold bg-red-300 text-red-800;
 }
 
 :disabled {
@@ -93,15 +93,28 @@ button.services {
 .carousel {
   scrollbar-width: thin;
   scroll-behavior: auto;
-   }
+}
 
-   .contact {
-    animation: tilt 2s linear infinite;
+.contact {
+  animation: tilt 2s linear infinite;
+}
+
+@keyframes tilt {
+
+  0%,
+  100% {
+    transform: translate(-50%, -50%) rotate(-15deg);
   }
 
-  @keyframes tilt {
-    0%, 100% { transform: translate(-50%, -50%) rotate(-15deg); }
-    25% { transform: translate(-50%, -50%) rotate(0deg); }
-    50% { transform: translate(-50%, -50%) rotate(15deg); }
-    75% { transform: translate(-50%, -50%) rotate(0deg); }
+  25% {
+    transform: translate(-50%, -50%) rotate(0deg);
   }
+
+  50% {
+    transform: translate(-50%, -50%) rotate(15deg);
+  }
+
+  75% {
+    transform: translate(-50%, -50%) rotate(0deg);
+  }
+}

--- a/src/pages/ServiceRequest.jsx
+++ b/src/pages/ServiceRequest.jsx
@@ -15,6 +15,7 @@ const ServiceRequest = () => {
     start: "",
     end: "",
   });
+  const [serviceError, setServiceError] = useState(false);
   const [slotError, setSlotError] = useState(false);
 
   const { steps, currentStepIndex, step, isFirstStep, isLastStep, back, next } =
@@ -32,11 +33,8 @@ const ServiceRequest = () => {
     e.preventDefault();
     setSlotError(false);
 
-    if (!appointment.service_id) {
-      setMessage({
-        style: "failure",
-        text: "Please select a service before continuing.",
-      });
+    if (currentStepIndex === 0 && !appointment.service_id) {
+      setServiceError(true);
       return;
     }
 
@@ -90,6 +88,11 @@ const ServiceRequest = () => {
         {currentStepIndex + 1} / {steps.length}
       </div>
       {step}
+      {serviceError && (
+        <p className="text-center text-red-500 mt-3">
+          Please select a service before continuing.
+        </p>
+      )}
       {slotError && (
         <p className="text-center text-red-500 mt-3">
           Please select a date and time before continuing.

--- a/src/pages/ServiceRequest.jsx
+++ b/src/pages/ServiceRequest.jsx
@@ -8,7 +8,7 @@ import { Context } from "../context/Context";
 import Button from "/src/components/Button.jsx";
 
 const ServiceRequest = () => {
-  const { selectedService, appointment, setAppointment } = useContext(Context);
+  const { appointment, setAppointment } = useContext(Context);
   const [message, setMessage] = useState(null);
   const [selectedSlot, setSelectedSlot] = useState({
     date: "",
@@ -32,7 +32,7 @@ const ServiceRequest = () => {
     e.preventDefault();
     setSlotError(false);
 
-    if (!selectedService) {
+    if (!appointment.service_id) {
       setMessage({
         style: "failure",
         text: "Please select a service before continuing.",


### PR DESCRIPTION
<img width="1512" alt="Screenshot 2025-03-24 at 8 08 02 PM" src="https://github.com/user-attachments/assets/806fd5eb-7179-4f80-8d38-5f1ed241055e" />
<img width="1510" alt="Screenshot 2025-03-24 at 8 08 30 PM" src="https://github.com/user-attachments/assets/62cff98c-d854-4d8b-a483-d9d920ae9c2f" />
Fixed the bug where the client could select a service, close the modal, and then start booking process again without selecting a service.
 - Changed service error to check the appointment state for a service_id, as that state is reset on modal close
 - Changed render method of the error message to match that of the selectedSlot error
 - Added mild style improvements to submission status message (success, failure classes)
