### PR TITLE
Fix inventory check table bug

### DIFF
--- a/src/components/AppointmentDetails.jsx
+++ b/src/components/AppointmentDetails.jsx
@@ -132,10 +132,10 @@ function AppointmentDetails({ appointment, setAppointment }) {
                   <th className="px-4 py-2 font-semibold">Item Name</th>
                   <th className="px-4 py-2 font-semibold">Qty Needed</th>
                   <th className="px-4 py-2 font-semibold">Stock</th>
-                  {items.outOfStock && (
-                    <th className="px-4 py-2 font-semibold">Restock</th>
-                  )}
-
+                  <th className="px-4 py-2 font-semibold">{items.outOfStock
+                    ? "Restock"
+                    : (<div className="text-gray-300 text-xs italic text-center">—</div>)}
+                  </th>
                   <th className="px-4 py-2 font-semibold">Unit Price</th>
                 </tr>
               </thead>
@@ -146,11 +146,10 @@ function AppointmentDetails({ appointment, setAppointment }) {
                     <td className="px-4 py-2">{item.qty_needed}</td>
                     <td className="px-4 py-2">
                       <span
-                        className={`px-3 py-1 rounded-full text-xs font-semibold ${
-                          item.outOfStock
-                            ? "bg-red-200 text-red-700"
-                            : "bg-green-200 text-green-700"
-                        }`}
+                        className={`px-3 py-1 rounded-full text-xs font-semibold ${item.outOfStock
+                          ? "bg-red-200 text-red-700"
+                          : "bg-green-200 text-green-700"
+                          }`}
                       >
                         {item.outOfStock
                           ? "Out of Stock"


### PR DESCRIPTION
<img width="1512" alt="Screenshot 2025-03-24 at 8 29 33 PM" src="https://github.com/user-attachments/assets/beee3ff9-51a0-44e1-9e7d-30c874da99ba" />
When no items were out of stock, one of the th elements would not be rendered. Meanwhile, the data part of the table was rendering an element regardless of the 'out of stock' condition. This caused the Unit Price data to be floating free of its column head.

I moved the conditional logic for the "Restock" column to inside the th element, rendering the same grey dash div from the data portion of the table if no items are out of stock.